### PR TITLE
mesen2+sameboy: parallelize make build

### DIFF
--- a/mesen2-git/PKGBUILD
+++ b/mesen2-git/PKGBUILD
@@ -1,13 +1,15 @@
 # Maintainer: Eldred Habert <arch@eldred.fr>
+# Contributor: kleines Filmröllchen <kleines@filmroellchen.eu>
+
 pkgname=mesen2-git
-pkgver=r3251.18269da4
+pkgver=r3343.af9eda35
 pkgrel=1
 pkgdesc="Multi-system emulator (NES, SNES, Game Boy and PC Engine)"
 arch=('x86_64')
 url="https://www.mesen.ca"
 license=('GPL3')
 depends=(libevdev sdl2)
-makedepends=(dotnet-sdk-8.0 git zip clang)
+makedepends=(dotnet-sdk-8.0 git zip clang coreutils)
 provides=("${pkgname%-git}")
 conflicts=("${pkgname%-git}")
 options=(!strip !debug) # Reportedly, these break with C#..?
@@ -25,7 +27,7 @@ pkgver() {
 
 build() {
 	cd "$srcdir/${pkgname%-git}"
-	make LTO=true SYSTEM_LIBEVDEV=true STATICLINK=false USE_AOT=true # Uses Clang by default, which speeds up emulation by about 40%.
+	MAKEFLAGS="${MAKEFLAGS} -j$(nproc)" make  LTO=true SYSTEM_LIBEVDEV=true STATICLINK=false USE_AOT=true # Uses Clang by default, which speeds up emulation by about 40%.
 }
 
 package() {

--- a/sameboy-git/PKGBUILD
+++ b/sameboy-git/PKGBUILD
@@ -1,10 +1,11 @@
 # Maintainer: Jakub Kądziołka <kuba@kadziolka.net>
 # Maintainer: basxto <archlinux basxto de>
 # Maintainer: ISSOtm <arch@eldred.fr>
+# Contributor: kleines Filmröllchen <kleines@filmroellchen.eu>
 
 pkgname=sameboy-git
 pkgdesc="An accuracy-focused Game Boy/Game Boy Color emulator"
-pkgver=0.16.6.r54.d34579e
+pkgver=1.0.r17.4e35048
 pkgrel=1
 arch=(x86_64)
 url="https://github.com/LIJI32/SameBoy"
@@ -13,7 +14,7 @@ provides=(sameboy)
 conflicts=(sameboy)
 depends=(sdl2 hicolor-icon-theme)
 # Upstream suggests using clang, but gcc is supported on Linux: https://github.com/LIJI32/SameBoy/issues/164#issuecomment-486464194
-makedepends=(rgbds make git)
+makedepends=(rgbds make git coreutils)
 source=(git+https://github.com/LIJI32/SameBoy)
 sha1sums=('SKIP')
 
@@ -23,7 +24,7 @@ pkgver() {
 }
 
 build() {
-	make -C SameBoy sdl xdg-thumbnailer CONF=release PREFIX=/usr
+	MAKEFLAGS="${MAKEFLAGS} -j$(nproc)"	make -C SameBoy sdl xdg-thumbnailer CONF=release PREFIX=/usr
 }
 
 package() {


### PR DESCRIPTION
For Mesen, this speeds up the build massively; while writing this patchset and testing it twice, the upstream package update didn’t even complete compiling the Mesen core. On my 2014 Xeon, this cuts down the Mesen build time to 9 minutes. sameboy builds in 14 *seconds* including the source download.

Also drive-by tag update for sameboy, I hope that’s acceptable.